### PR TITLE
Fix OpenAPIParser deprecation warning

### DIFF
--- a/committee.gemspec
+++ b/committee.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "json_schema", "~> 0.14", ">= 0.14.3"
 
   s.add_dependency "rack", ">= 1.5"
-  s.add_dependency "openapi_parser", ">= 0.6.1"
+  s.add_dependency "openapi_parser", "~> 1.0"
 
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "rack-test", "~> 0.6"

--- a/lib/committee/drivers.rb
+++ b/lib/committee/drivers.rb
@@ -50,7 +50,7 @@ module Committee
     # @return [Committee::Driver]
     def self.load_from_data(hash)
       if hash['openapi']&.start_with?('3.0.')
-        parser = OpenAPIParser.parse(hash)
+        parser = OpenAPIParser.parse(hash, { strict_reference_validation: false })
         return Committee::Drivers::OpenAPI3::Driver.new.parse(parser)
       end
 


### PR DESCRIPTION
Fixes deprecation warnings of the `openapi_parser` library (which got added with the newest version I assume). We might need to do the same with the parse method on the `open_api_test_helper`

See: https://github.com/ota42y/openapi_parser#reference-validation-on-schema-load